### PR TITLE
fix target crash issue caused by movaps alignment requirement

### DIFF
--- a/inject-x86_64.c
+++ b/inject-x86_64.c
@@ -35,6 +35,7 @@ void injectSharedLibrary(long mallocaddr, long freeaddr, long dlopenaddr)
 
 	// save addresses of free() and __libc_dlopen_mode() on the stack for later use
 	asm(
+		"and $0xfffffffffffff000, %rsp \n"
 		// rsi is going to contain the address of free(). it's going to get wiped
 		// out by the call to malloc(), so save it on the stack for later
 		"push %rsi \n"


### PR DESCRIPTION
On some machines of linux x86_64, dlopen() may use movaps instruction, and this requires the target memory (often the stack) to be properly aligned. If not, it will crash the program.

For example, on my machine, the injection failed with this error:

```
instead of expected SIGTRAP, target stopped with signal 11: Segmentation fault
sending process 9862 a SIGSTOP signal for debugging purposes
```

Then after I attached gdb to the injected process. I found it stopped at movaps instruction

```
   0x7f4d7be675cc:      mov    %r12,0x30(%rsp)
   0x7f4d7be675d1:      movhps 0xb0(%rsp),%xmm0
   0x7f4d7be675d9:      mov    %ebp,0x38(%rsp)
=> 0x7f4d7be675dd:      movaps %xmm0,0x60(%rsp)
   0x7f4d7be675e2:      movq   $0x0,0x48(%rsp)
   0x7f4d7be675eb:      mov    %rbx,0x50(%rsp)
```
and current RSP is 0x7ffe3049fb78. It is not aligned as required.

You can find movaps's alignment issue in detail here: https://www.felixcloutier.com/x86/movaps

Adding a `and $0xfffffffffffff000, %rsp \n` to the beginning of the shellcode should fix this.


